### PR TITLE
dev: stuff

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -7,3 +7,7 @@ starknet = "2.3.1"
 openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.8.0" }
 
 [[target.starknet-contract]]
+
+[tool.fmt]
+sort-module-level-items = true
+max-line-length = 120

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -4,17 +4,13 @@ mod tokens;
 
 #[starknet::interface]
 trait IMarket<TContractState> {
-    fn create(
-        ref self: TContractState, token_id: u32, collection_id: u16, price: u128, expiration: u64,
-    );
+    fn create(ref self: TContractState, token_id: u32, collection_id: u16, price: u128, expiration: u64,);
     fn accept(ref self: TContractState, order_id: felt252);
     fn cancel(ref self: TContractState, order_id: felt252);
     fn edit(ref self: TContractState, order_id: felt252, new_price: u128);
-    fn whitelist_collection(
-        ref self: TContractState, collection_address: core::starknet::ContractAddress
-    );
-    fn update_owner_fee(ref self: TContractState, fee: felt252);
-    fn update_owner_address(ref self: TContractState, new_address: core::starknet::ContractAddress);
+    fn whitelist_collection(ref self: TContractState, collection_address: core::starknet::ContractAddress);
+    fn update_market_fee(ref self: TContractState, fee: felt252);
+    fn update_market_owner_address(ref self: TContractState, new_address: core::starknet::ContractAddress);
     fn view_order(ref self: TContractState, order_id: felt252) -> marketplace::packing::MarketOrder;
     fn pause(ref self: TContractState);
     fn unpause(ref self: TContractState);
@@ -22,25 +18,17 @@ trait IMarket<TContractState> {
 
 #[starknet::contract]
 mod Market {
-    use core::debug::PrintTrait;
-    use super::IMarket;
-    use marketplace::packing::{MarketOrderTrait, MarketOrder, ORDER_STATE};
-
-    use core::{
-        starknet::{
-            get_caller_address, ContractAddress, get_block_timestamp, info::BlockInfo,
-            get_contract_address
-        },
-    };
+    use core::zeroable::Zeroable;
+    use marketplace::packing::MarketOrder;
 
     use openzeppelin::token::erc20::interface::{
-        IERC20Dispatcher, IERC20DispatcherImpl, IERC20Camel, IERC20CamelDispatcher,
-        IERC20CamelDispatcherTrait, IERC20CamelLibraryDispatcher
+        IERC20Dispatcher, IERC20DispatcherImpl, IERC20CamelDispatcher, IERC20CamelDispatcherTrait
     };
 
-    use openzeppelin::token::erc721::interface::{
-        IERC721Dispatcher, IERC721DispatcherTrait, IERC721LibraryDispatcher
-    };
+    use openzeppelin::token::erc721::interface::{IERC721Dispatcher, IERC721DispatcherTrait,};
+
+    use starknet::{get_caller_address, ContractAddress, get_block_timestamp, get_contract_address};
+    use super::IMarket;
 
     #[event]
     #[derive(Drop, starknet::Event)]
@@ -57,53 +45,48 @@ mod Market {
     #[storage]
     struct Storage {
         market_order: LegacyMap::<felt252, MarketOrder>, // order
-        owner: LegacyMap::<felt252, ContractAddress>, // owner of order
         order_count: felt252,
-        collection_address: LegacyMap::<felt252, ContractAddress>, // collection addresses
-        collection_count: felt252,
-        erc_address: ContractAddress,
-        owner_fee: felt252,
-        owner_address: ContractAddress,
+        collection_address: LegacyMap::<u16, IERC721Dispatcher>, // collection addresses
+        collection_count: u16,
+        fee_token: IERC20Dispatcher,
+        market_fee: felt252,
+        market_owner_address: ContractAddress,
         paused: bool,
     }
 
     #[constructor]
     fn constructor(
-        ref self: ContractState,
-        _erc20_address: ContractAddress,
-        _fee: felt252,
-        _owner_address: ContractAddress
+        ref self: ContractState, fee_token_address: ContractAddress, fee: felt252, market_owner_address: ContractAddress
     ) {
-        self.erc_address.write(_erc20_address);
-        self.owner_fee.write(_fee);
-        self.owner_address.write(_owner_address);
-        self.paused.write(false);
+        self.fee_token.write(IERC20Dispatcher { contract_address: fee_token_address });
+        self.market_fee.write(fee);
+        self.market_owner_address.write(market_owner_address);
     }
 
     // Pauses the accept order function, in the event of a bug or exploit.
+    #[inline(always)]
     fn assert_not_paused(self: @ContractState) {
         assert(!self.paused.read(), 'MARKET: paused');
     }
 
+    #[inline(always)]
+    fn assert_order_active(order: MarketOrder) {
+        assert(order.active, 'MARKET: order not active');
+    }
+
     // Checks if the caller is the DAO multisig.
+    #[inline(always)]
     fn assert_only_market_owner(self: @ContractState) {
-        assert(self.owner_address.read() == get_caller_address(), 'MARKET: caller not owner');
+        assert(self.market_owner_address.read() == get_caller_address(), 'MARKET: caller not owner');
     }
 
     // Checks if the caller is the order owner.
-    fn assert_only_market_order_owner(self: @ContractState, order_id: felt252) {
-        assert(self.owner.read(order_id) == get_caller_address(), 'MARKET: caller not order owner');
+    #[inline(always)]
+    fn assert_only_market_order_owner(self: @ContractState, order: MarketOrder) {
+        assert(order.owner == get_caller_address(), 'MARKET: caller not order owner');
     }
 
-    fn erc20_dispatcher(self: @ContractState) -> IERC20Dispatcher {
-        IERC20Dispatcher { contract_address: self.erc_address.read(), }
-    }
-
-    fn erc721_dispatcher(self: @ContractState, collection_id: felt252) -> IERC721Dispatcher {
-        IERC721Dispatcher { contract_address: self.collection_address.read(collection_id), }
-    }
-
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl Market of IMarket<ContractState> {
         // =========================
         // === MARKET FUNCTIONS ====
@@ -114,57 +97,32 @@ mod Market {
         /// increments the order count, sets the market order in state, and emits an OrderEvent.
         /// # Arguments
         /// * `market_order` - The market order to be created.
-        fn create(
-            ref self: ContractState,
-            token_id: u32,
-            collection_id: u16,
-            price: u128,
-            expiration: u64,
-        ) {
+        fn create(ref self: ContractState, token_id: u32, collection_id: u16, price: u128, expiration: u64,) {
             // create market order
-            let market_order = MarketOrder {
-                token_id: token_id,
-                collection_id: collection_id,
-                price: price,
-                expiration: expiration,
-                active: ORDER_STATE::ACTIVE,
-            };
+            let caller = get_caller_address();
+            let market_order = MarketOrder { owner: caller, token_id, collection_id, price, expiration, active: true };
+            let collection_dispatcher = self.collection_address.read(market_order.collection_id);
 
             // assert collection is whitelisted
             // @dev: collections need to be whitelisted
-            assert(
-                self.collection_address.read(market_order.collection_id.into()).into() != 0,
-                'MARKET: Not whitelisted'
-            );
+            assert(collection_dispatcher.contract_address.is_non_zero(), 'MARKET: Not whitelisted');
 
             // assert market is approved
             // @dev: a tx should be sent before calling this authorizing the contract to transfer the NFT
-            assert(
-                erc721_dispatcher(@self, market_order.collection_id.into())
-                    .is_approved_for_all(get_caller_address(), get_contract_address()),
-                'MARKET: Not approved'
-            );
+            assert(collection_dispatcher.is_approved_for_all(caller, get_contract_address()), 'MARKET: Not approved');
 
             // assert expiration is in the future and at least 1 day
-            assert(
-                market_order.expiration > get_block_timestamp() + 86400, 'MARKET: Not in future'
-            );
+            assert(market_order.expiration > get_block_timestamp() + 86400, 'MARKET: Not in future');
 
             // assert owner of NFT is caller
-            assert(
-                erc721_dispatcher(@self, market_order.collection_id.into())
-                    .owner_of(market_order.token_id.into()) == get_caller_address(),
-                'MARKET: Not owner'
-            );
+            assert(collection_dispatcher.owner_of(market_order.token_id.into()) == caller, 'MARKET: Not owner');
 
             // increment
-            let mut count = self.order_count.read();
-            count += 1;
+            let count = self.order_count.read() + 1;
 
             // set market order // set count // set owner of bounty
             self.market_order.write(count, market_order);
             self.order_count.write(count);
-            self.owner.write(count, get_caller_address());
 
             // emit event
             self.emit(OrderEvent { market_order, timestamp: get_block_timestamp() });
@@ -181,42 +139,32 @@ mod Market {
             // get order
             let mut market_order = self.market_order.read(order_id);
 
-            // get owner
-            let order_owner = self.owner.read(order_id);
-
-            // we assert here - as the buyer can revoke approval at any time
-            // asserting here means the trade will fail if the buyer has revoked approval
-            // the trade should be removed from the indexer if revert happens
-            assert(
-                erc721_dispatcher(@self, market_order.collection_id.into())
-                    .is_approved_for_all(order_owner, get_contract_address()),
-                'MARKET: Not approved'
-            );
-
-            // assert expiration    
+            // assert expiration
             assert(market_order.expiration > get_block_timestamp(), 'MARKET: Expired');
 
             // assert active
-            market_order.is_active();
+            assert_order_active(market_order);
+
+            let caller = get_caller_address();
 
             // calculate cost minus fee
             let cost = market_order.price.into();
-            let fee: u256 = cost * self.owner_fee.read().into() / 10000;
+            let fee: u256 = cost * self.market_fee.read().into() / 10000;
 
             // LORDS: transfer fee to owner
-            erc20_dispatcher(@self)
-                .transfer_from(get_caller_address(), self.owner_address.read(), fee.into());
+            self.fee_token.read().transfer_from(caller, self.market_owner_address.read(), fee.into());
 
             // LORDS: transfer cost minus fee from buyer to seller
-            erc20_dispatcher(@self)
-                .transfer_from(get_caller_address(), order_owner, (cost.into() - fee).into());
+            self.fee_token.read().transfer_from(caller, market_order.owner, (cost.into() - fee).into());
 
             // NFT: from seller to buyer
-            erc721_dispatcher(@self, market_order.collection_id.into())
-                .transfer_from(order_owner, get_caller_address(), market_order.token_id.into());
+            self
+                .collection_address
+                .read(market_order.collection_id)
+                .transfer_from(market_order.owner, caller, market_order.token_id.into());
 
             // set inactive
-            market_order.set_inactive();
+            market_order.active = false;
             self.market_order.write(order_id, market_order);
 
             // emit event
@@ -232,13 +180,13 @@ mod Market {
             let mut market_order = self.market_order.read(order_id);
 
             // assert active
-            market_order.is_active();
+            assert_order_active(market_order);
 
             // assert owner
-            assert_only_market_order_owner(@self, order_id);
+            assert_only_market_order_owner(@self, market_order);
 
             // set inactive
-            market_order.set_inactive();
+            market_order.active = false;
             self.market_order.write(order_id, market_order);
 
             // emit event
@@ -254,17 +202,17 @@ mod Market {
             let mut market_order = self.market_order.read(order_id);
 
             // assert active
-            market_order.is_active();
+            assert_order_active(market_order);
 
             // assert owner
-            assert_only_market_order_owner(@self, order_id);
+            assert_only_market_order_owner(@self, market_order);
 
             // update price
             market_order.price = new_price;
             self.market_order.write(order_id, market_order);
 
             // emit event
-            self.emit(OrderEvent { market_order: market_order, timestamp: get_block_timestamp() });
+            self.emit(OrderEvent { market_order, timestamp: get_block_timestamp() });
         }
 
         // =========================
@@ -289,28 +237,27 @@ mod Market {
             assert_only_market_owner(@self);
 
             // increment
-            let mut count = self.collection_count.read();
-            count += 1;
+            let count = self.collection_count.read() + 1;
 
             // set count // set owner of bounty
-            self.collection_address.write(count, collection_address);
+            self.collection_address.write(count, IERC721Dispatcher { contract_address: collection_address });
             self.collection_count.write(count);
         }
 
         /// Updates the DAO fee. Can only be called by the DAO multisig.
         /// # Arguments
         /// * `fee` - The new fee.
-        fn update_owner_fee(ref self: ContractState, fee: felt252) {
+        fn update_market_fee(ref self: ContractState, fee: felt252) {
             assert_only_market_owner(@self);
-            self.owner_fee.write(fee);
+            self.market_fee.write(fee);
         }
 
         /// Updates the DAO address. Can only be called by the DAO multisig.
         /// # Arguments
         /// * `new_address` - The new DAO address.
-        fn update_owner_address(ref self: ContractState, new_address: ContractAddress) {
+        fn update_market_owner_address(ref self: ContractState, new_address: ContractAddress) {
             assert_only_market_owner(@self);
-            self.owner_address.write(new_address);
+            self.market_owner_address.write(new_address);
         }
 
         /// Pauses the contract. Can only be called by the DAO multisig

--- a/src/tests.cairo
+++ b/src/tests.cairo
@@ -1,49 +1,44 @@
 #[cfg(test)]
 mod test {
     use core::debug::PrintTrait;
-    use debug::print;
-    // use marketplace::tokens::erc721::ERC721Component;
-    use marketplace::IMarketDispatcherTrait;
-    use marketplace::{IMarket, IMarketDispatcher, Market};
-    use marketplace::packing::MarketOrderTrait;
-    use marketplace::packing::{MarketOrder, ORDER_STATE};
 
     use core::{
-        array::{SpanTrait, ArrayTrait}, integer::u256_try_as_non_zero, traits::{TryInto, Into},
-        clone::Clone, poseidon::poseidon_hash_span, option::OptionTrait, box::BoxTrait,
+        array::{SpanTrait, ArrayTrait}, integer::u256_try_as_non_zero, traits::{TryInto, Into}, clone::Clone,
+        poseidon::poseidon_hash_span, option::OptionTrait, box::BoxTrait,
         starknet::{
             get_caller_address, ContractAddress, ContractAddressIntoFelt252, contract_address_const,
             get_block_timestamp, info::BlockInfo, get_contract_address
         },
     };
-    use starknet::{syscalls::deploy_syscall, testing};
-    use openzeppelin::token::erc20::interface::{
-        IERC20Camel, IERC20CamelDispatcher, IERC20CamelDispatcherTrait, IERC20CamelLibraryDispatcher
-    };
 
-    use openzeppelin::token::erc721::interface::{
-        IERC721Dispatcher, IERC721DispatcherTrait, IERC721LibraryDispatcher
-    };
-    use openzeppelin::utils::serde::SerializedAppend;
-    use openzeppelin::tests::utils;
+    use marketplace::IMarketDispatcherTrait;
+    use marketplace::packing::MarketOrder;
 
-    const MAX_LORDS: u256 = 10000000000000000000000000000000000000000;
-    const APPROVE: u256 = 10000000000000000000000000000000000000000;
+    use marketplace::tokens::erc721::MyNFT;
+    use marketplace::{IMarket, IMarketDispatcher, Market};
+    use openzeppelin::tests::mocks::erc20_mocks::{DualCaseERC20};
 
     use openzeppelin::tests::utils::constants::{
         DATA, ZERO, OWNER, RECIPIENT, SPENDER, OPERATOR, OTHER, NAME, SYMBOL, URI, PUBKEY
     };
+    use openzeppelin::tests::utils;
+    use openzeppelin::token::erc20::interface::{
+        IERC20Camel, IERC20CamelDispatcher, IERC20CamelDispatcherTrait, IERC20CamelLibraryDispatcher
+    };
+
+    use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
+
+    use openzeppelin::token::erc721::interface::{IERC721Dispatcher, IERC721DispatcherTrait, IERC721LibraryDispatcher};
+    use openzeppelin::utils::serde::SerializedAppend;
+    use starknet::syscalls::deploy_syscall;
+    use starknet::testing::{set_caller_address, set_contract_address};
+
+    const MAX_LORDS: u256 = 10000000000000000000000000000000000000000;
+    const APPROVE: u256 = 10000000000000000000000000000000000000000;
 
     fn DAO() -> ContractAddress {
         contract_address_const::<1>()
     }
-    use starknet::testing::set_caller_address;
-    use starknet::testing::set_contract_address;
-
-    use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
-    use openzeppelin::tests::mocks::erc20_mocks::{DualCaseERC20};
-
-    use marketplace::tokens::erc721::MyNFT;
 
     const TOKEN_ID: u256 = 1;
     const ORDER_ID: felt252 = 1;
@@ -136,13 +131,7 @@ mod test {
 
         set_contract_address(RECIPIENT());
 
-        market
-            .create(
-                token_id: TOKEN_ID.try_into().unwrap(),
-                collection_id: 1,
-                price: PRICE,
-                expiration: 100,
-            );
+        market.create(token_id: TOKEN_ID.try_into().unwrap(), collection_id: 1, price: PRICE, expiration: 100,);
     }
     // ==================== ACCEPT ====================
 
@@ -174,7 +163,7 @@ mod test {
 
         let order = market.view_order(ORDER_ID);
 
-        assert(order.active == ORDER_STATE::INACTIVE, 'Not active');
+        assert(!order.active, 'Not active');
     }
 
     // ==================== EDIT ====================
@@ -208,7 +197,7 @@ mod test {
 
         let order = market.view_order(ORDER_ID);
 
-        assert(order.active == ORDER_STATE::INACTIVE, 'Not active');
+        assert(!order.active, 'Not active');
     }
 
     #[test]
@@ -218,7 +207,7 @@ mod test {
 
         set_contract_address(DAO());
 
-        market.update_owner_fee(400);
+        market.update_market_fee(400);
     }
 
     #[test]
@@ -229,6 +218,6 @@ mod test {
 
         set_contract_address(RECIPIENT());
 
-        market.update_owner_fee(400);
+        market.update_market_fee(400);
     }
 }

--- a/src/tokens/erc721.cairo
+++ b/src/tokens/erc721.cairo
@@ -15,8 +15,7 @@ mod MyNFT {
     #[abi(embed_v0)]
     impl ERC721CamelOnly = ERC721Component::ERC721CamelOnlyImpl<ContractState>;
     #[abi(embed_v0)]
-    impl ERC721MetadataCamelOnly =
-        ERC721Component::ERC721MetadataCamelOnlyImpl<ContractState>;
+    impl ERC721MetadataCamelOnly = ERC721Component::ERC721MetadataCamelOnlyImpl<ContractState>;
     impl ERC721InternalImpl = ERC721Component::InternalImpl<ContractState>;
 
     // SRC5
@@ -53,9 +52,7 @@ mod MyNFT {
 
     #[generate_trait]
     impl InternalImpl of InternalTrait {
-        fn _mint_with_uri(
-            ref self: ContractState, recipient: ContractAddress, token_id: u256, token_uri: felt252
-        ) {
+        fn _mint_with_uri(ref self: ContractState, recipient: ContractAddress, token_id: u256, token_uri: felt252) {
             // Initialize the ERC721 storage
             self.erc721._mint(recipient, token_id);
             // Mint the NFT to recipient and set the token's URI


### PR DESCRIPTION
Various stuff:

* using scarb formatting `scarb fmt`
* directly storing dispatchers
* added `owner` directly to `MarketOrder` to remove one storage var in the contract
* renamed `owner` to `market_owner` and `owner_fee` to `market_fee` to be more explicit
* removed some of the 721 checks because they are done in the `transfer_from`

Additional suggesetions:
* emit an event on every storage change (e.g. in `update_market_fee`, `update_market_owner_address` and so on) for transparency
* IMO no need to emit a block timestamp in events, since that's in an event's metadata
* what's the purpose of  the `fee / 10000` in `accept`? and since it's a constant, it could be calculated when setting the fee already (in constructor and the update fn)
* there's no way how to update an order's expiration, only price, maybe add that?

As mentioned in chat, this will only work on collections that already respect `snake_case` functionality. Same for the fee token, but since it's $LORDS, all is good there.
